### PR TITLE
Adding scripts for cl_papers.csv and tacl_papes.csv

### DIFF
--- a/acl2020_tools/utils/process_cl_papers.py
+++ b/acl2020_tools/utils/process_cl_papers.py
@@ -1,0 +1,60 @@
+import argparse
+import csv
+
+import pandas as pd
+
+from acl2020_tools.utils.paper_import import clean_abstract, clean_title, extract_slot
+
+
+def format_author_names(csv_authors):
+    return "|".join(x.strip() for x in csv_authors.split(","))
+
+
+def process_cl_papers(cl_xlsx: str, slot_xlsx: str, output_file: str):
+    raw_df = pd.read_excel(cl_xlsx)
+
+    slots_df = pd.read_excel(slot_xlsx, 1)
+    cl_slots = slots_df.loc[
+        slots_df["paper pub venue"].apply(lambda x: x.strip().lower())
+        == "computational linguistics"
+    ]
+    cl_slots["Submission ID"] = cl_slots["ID"].apply(lambda x: int(str(x)[1:])).copy()
+    concatenated_df = pd.merge(raw_df, cl_slots, on="Submission ID")
+
+    cl_clean_df = pd.DataFrame()
+
+    cl_clean_df["UID"] = "cl." + raw_df["Submission ID"].astype("str")
+    cl_clean_df.set_index("UID", verify_integrity=True)
+
+    cl_clean_df["title"] = concatenated_df["Title_x"].apply(clean_title)
+    cl_clean_df["authors"] = concatenated_df["Authors_x"].apply(format_author_names)
+    cl_clean_df["abstract"] = concatenated_df["Abstract"].apply(clean_abstract)
+    cl_clean_df["paper_track"] = concatenated_df["slot 1"].apply(extract_slot)
+    cl_clean_df["paper_type"] = "CL"
+    cl_clean_df["pdf_url"] = concatenated_df["URL"]
+
+    cl_clean_df.to_csv(
+        output_file, sep=",", index=False, encoding="utf-8", quoting=csv.QUOTE_ALL
+    )
+
+
+if __name__ == "__main__":
+
+    cmdline_parser = argparse.ArgumentParser(description=__doc__)
+
+    cmdline_parser.add_argument(
+        "--cl_xlsx_file",
+        help="ACL2020.CL.papers.xlsx from https://github.com/acl-org/acl-2020-virtual-conference-sitedata/pull/73/files",
+    )
+    cmdline_parser.add_argument("--output_file", help="output cl_papers.csv file")
+    cmdline_parser.add_argument(
+        "--qa_session_xlsx",
+        help="ACL 2020 live Q&A schedule (for authors).xlsx file to extract slots",
+    )
+    args = cmdline_parser.parse_args()
+
+    process_cl_papers(
+        cl_xlsx=args.cl_xlsx_file,
+        slot_xlsx=args.qa_session_xlsx,
+        output_file=args.output_file,
+    )

--- a/acl2020_tools/utils/process_tacl_papers.py
+++ b/acl2020_tools/utils/process_tacl_papers.py
@@ -1,0 +1,64 @@
+import argparse
+import csv
+
+import pandas as pd
+
+from acl2020_tools.utils.paper_import import clean_abstract, clean_title, extract_slot
+
+
+def reformat_to_psv(org_format: str, sep: str):
+    return "|".join(x.strip() for x in org_format.split(sep))
+
+
+def process_tacl_papers(tacl_xlsx: str, slot_xlsx: str, output_file: str):
+    raw_df = pd.read_excel(tacl_xlsx)
+
+    slots_df = pd.read_excel(slot_xlsx, 1)
+    tacl_slots = slots_df.loc[
+        slots_df["paper pub venue"].apply(lambda x: x.strip().lower()) == "tacl"
+    ]
+    tacl_slots["ID"] = tacl_slots["ID"].apply(lambda x: int(str(x)[2:]))
+    concatenated_df = pd.merge(raw_df, tacl_slots, on="ID")
+
+    tacl_clean_df = pd.DataFrame()
+
+    tacl_clean_df["UID"] = "tacl." + concatenated_df["ID"].astype("str")
+    tacl_clean_df.set_index("UID", verify_integrity=True)
+
+    tacl_clean_df["title"] = concatenated_df["Title_x"].apply(clean_title)
+    tacl_clean_df["authors"] = concatenated_df["Authors_x"].apply(
+        reformat_to_psv, args=(",")
+    )
+    tacl_clean_df["abstract"] = concatenated_df["Abstract"].apply(clean_abstract)
+    tacl_clean_df["paper_track"] = concatenated_df["slot 1"].apply(extract_slot)
+    tacl_clean_df["paper_type"] = "TACL"
+    tacl_clean_df["pdf_url"] = concatenated_df["Links"]
+    tacl_clean_df["emails"] = concatenated_df["Emails"].apply(
+        reformat_to_psv, args=(";")
+    )
+
+    tacl_clean_df.to_csv(
+        output_file, sep=",", index=False, encoding="utf-8", quoting=csv.QUOTE_ALL
+    )
+
+
+if __name__ == "__main__":
+
+    cmdline_parser = argparse.ArgumentParser(description=__doc__)
+
+    cmdline_parser.add_argument(
+        "--tacl_xlsx_file",
+        help="ACL2020.TACL.papers.xlsx from https://github.com/acl-org/acl-2020-virtual-conference-sitedata/pull/73/files",
+    )
+    cmdline_parser.add_argument(
+        "--qa_session_xlsx",
+        help="ACL 2020 live Q&A schedule (for authors).xlsx file to extract slots",
+    )
+    cmdline_parser.add_argument("--output_file", help="output tacl_papers.csv file")
+    args = cmdline_parser.parse_args()
+
+    process_tacl_papers(
+        tacl_xlsx=args.tacl_xlsx_file,
+        slot_xlsx=args.qa_session_xlsx,
+        output_file=args.output_file,
+    )

--- a/acl2020_tools/utils/qa_schedule_cl_tacl.py
+++ b/acl2020_tools/utils/qa_schedule_cl_tacl.py
@@ -1,0 +1,115 @@
+import argparse
+import re
+from collections import defaultdict
+from datetime import datetime
+
+import pandas as pd
+import yaml
+
+re_session_extract = re.compile(
+    r"\w+ (\w+) (\d+), (\d+) (\d+\w) [\w\d\s:\-.,()]+-\d+ (\d+):(\d\d) UTC(.*)"
+)
+
+
+def extract_date(x):
+    (month, date, year, session, hour, mins, timezone,) = re_session_extract.match(
+        x
+    ).groups()
+    month_int = datetime.strptime(month, "%B").month
+    parsed_date = datetime(int(year), month_int, int(date), int(hour), int(mins))
+    assert timezone == "+0"
+    return parsed_date, session
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Format paper details into MiniConf format"
+    )
+    parser.add_argument(
+        "--track_file",
+        help="Excel spreadsheet giving paper track, QA session times, and ID in the proceedings",
+        action="store",
+        type=str,
+        default="ACL 2020 live Q&A schedule (for authors).xlsx",
+    )
+    parser.add_argument(
+        "--sheet_name",
+        help="Excel sheet name for TACL and CL",
+        action="store",
+        type=str,
+        default="TACLCL Q&A schedule",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    track_details = pd.read_excel(args.track_file, args.sheet_name)
+    track_details.rename(columns={"paper pub venue": "PaperPubVenue"}, inplace=True)
+
+    track_details["Date1"], track_details["Session1"] = zip(
+        *track_details["slot 1"].map(extract_date)
+    )
+    track_details["Date2"], track_details["Session2"] = zip(
+        *track_details["slot 2"].map(extract_date)
+    )
+
+    cl_session_time_map = defaultdict(lambda: {"date": "", "papers": []})
+    tacl_session_time_map = defaultdict(lambda: {"date": "", "papers": []})
+
+    venue = {"Computational Linguistics": "cl", "TACL": "tacl"}
+
+    for row in track_details.itertuples():
+        # Strip 9 for CL papers and 99 for TACL papers.
+        if venue[row.PaperPubVenue] == "cl":
+            row_id = str(row.ID)[1:]
+            cl_session_time_map[row.Session1]["date"] = row.Date1
+            cl_session_time_map[row.Session1]["papers"].append(
+                venue[row.PaperPubVenue] + "." + str(row_id)
+            )
+            cl_session_time_map[row.Session2]["date"] = row.Date2
+            cl_session_time_map[row.Session2]["papers"].append(
+                venue[row.PaperPubVenue] + "." + str(row_id)
+            )
+        elif venue[row.PaperPubVenue] == "tacl":
+            row_id = str(row.ID)[2:]
+            tacl_session_time_map[row.Session1]["date"] = row.Date1
+            tacl_session_time_map[row.Session1]["papers"].append(
+                venue[row.PaperPubVenue] + "." + str(row_id)
+            )
+            tacl_session_time_map[row.Session2]["date"] = row.Date2
+            tacl_session_time_map[row.Session2]["papers"].append(
+                venue[row.PaperPubVenue] + "." + str(row_id)
+            )
+        else:
+            raise ValueError("Unknown venue")
+
+    # Sort everything CL
+    for session_info in cl_session_time_map.values():
+        session_info["papers"].sort(key=lambda x: int(x.split(".")[1]))
+    dict_items = list(cl_session_time_map.items())
+    dict_items.sort(key=lambda x: x[1]["date"])
+    cl_ordered_sessions = dict(dict_items)
+
+    for session_info in cl_session_time_map.values():
+        session_info["date"] = session_info["date"].strftime("%Y-%m-%d_%H:%M:%S")
+
+    with open("cl_paper_sessions.yml", "w") as f:
+        yaml.dump(cl_ordered_sessions, f, default_flow_style=False, sort_keys=False)
+
+    # Sort everything TACL
+    for session_info in tacl_session_time_map.values():
+        session_info["papers"].sort(key=lambda x: int(x.split(".")[1]))
+    dict_items = list(tacl_session_time_map.items())
+    dict_items.sort(key=lambda x: x[1]["date"])
+    tacl_ordered_sessions = dict(dict_items)
+
+    for session_info in tacl_session_time_map.values():
+        session_info["date"] = session_info["date"].strftime("%Y-%m-%d_%H:%M:%S")
+
+    with open("tacl_paper_sessions.yml", "w") as f:
+        yaml.dump(tacl_ordered_sessions, f, default_flow_style=False, sort_keys=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adding scripts for generating cl_papers.csv, tacl_papers.csv, cl_paper_sessions.yml and tacl_paper_sessions.yml
Files PR: https://github.com/acl-org/acl-2020-virtual-conference-sitedata/pull/78